### PR TITLE
"next" Branch

### DIFF
--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -4,7 +4,7 @@ name: Deploy static content to Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ["main"]
+    branches: ["next"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
This updates the Github ghpages workflow to build from the `next` branch instead of `main`. This will allow the `main` branch to stay in sync with releases