### PR TITLE
Fix: Monitor Entry Parsing

### DIFF
--- a/src/DataChart/mod.ts
+++ b/src/DataChart/mod.ts
@@ -105,10 +105,10 @@ export function fillChartDataRecords(
   xAxisData: Array<Dayjs>,
   yAxisRecord: Map<ChartDataField, Array<number | null>>,
   entry: IMonitorEntry,
-  timestamp?: string | Dayjs,
+  timestamp?: Dayjs,
 ) {
   if (timestamp) {
-    xAxisData.push(dateUtil(timestamp).utc().tz('America/Los_Angeles'));
+    xAxisData.push(timestamp.utc().tz('America/Los_Angeles'));
   } else {
     xAxisData.push(dateUtil(entry.timestamp).utc().tz('America/Los_Angeles'));
   }

--- a/src/DataChart/service.ts
+++ b/src/DataChart/service.ts
@@ -22,11 +22,11 @@ export async function fetchChartData(m: Monitor, d: DateRange): Promise<uPlot.Al
         const entry = entries[i];
 
         if (xAxisData.length > 1) {
+          const entrytime = dateUtil(entry.timestamp).utc().tz('America/Los_Angeles').toISOString();
           let prevTimestamp = dateUtil(xAxisData[xAxisData.length - 1]);
 
-          while (prevTimestamp.skewedDiff(entry.timestamp, updateDuration) > updateDuration + 1) {
+          while (prevTimestamp.skewedDiff(entrytime, updateDuration) > updateDuration + 1) {
             prevTimestamp = prevTimestamp.add(updateDuration, "m");
-
             fillChartDataRecords(xAxisData, yAxisRecord, entry, prevTimestamp)
           }
         }


### PR DESCRIPTION
Corrects monitor entry parsing by converting the raw entry timestamp prior to comparison with previously parsed timestamps