### PR TITLE
Fix/sjvair markers

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "files": [
     "dist"
   ],
-  "version": "1.33.0",
+  "version": "1.34.0",
   "type": "module",
   "scripts": {
     "dev": "VITE_BUILD_MODE='development' vite",

--- a/src/Monitors/Monitor.ts
+++ b/src/Monitors/Monitor.ts
@@ -66,7 +66,7 @@ function getMarkerParams(monitorData: IMonitorData): IMarkerParams {
           break;
         case "PurpleAir":
           if (monitorData.is_sjvair) {
-            params.size = 16
+            params.size = 12
           } else {
             params.size = 10;
           }


### PR DESCRIPTION
Shrinks size of SJVAir monitor markers to be able to select monitors layered behind the marker