### PR TITLE
Fix: Translation Errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sjvair/monitor-map",
-  "version": "1.8.9",
+  "version": "1.8.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sjvair/monitor-map",
-      "version": "1.8.9",
+      "version": "1.8.11",
       "devDependencies": {
         "@types/d3": "^7.4.3",
         "@types/leaflet": "^1.9.8",
@@ -28,7 +28,7 @@
         "uplot": "^1.6.30",
         "vite": "^5.1.4",
         "vite-plugin-purgecss": "^0.2.12",
-        "vue": "^3.4.19",
+        "vue": "^3.4.20",
         "vue-router": "^4.3.0",
         "vue-tsc": "^1.8.27"
       }
@@ -980,53 +980,53 @@
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.4.19",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.19.tgz",
-      "integrity": "sha512-gj81785z0JNzRcU0Mq98E56e4ltO1yf8k5PQ+tV/7YHnbZkrM0fyFyuttnN8ngJZjbpofWE/m4qjKBiLl8Ju4w==",
+      "version": "3.4.20",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.20.tgz",
+      "integrity": "sha512-l7M+xUuL8hrGtRLkrf+62d9zucAdgqNBTbJ/NufCOIuJQhauhfyAKH9ra/qUctCXcULwmclGAVpvmxjbBO30qg==",
       "dev": true,
       "dependencies": {
         "@babel/parser": "^7.23.9",
-        "@vue/shared": "3.4.19",
+        "@vue/shared": "3.4.20",
         "entities": "^4.5.0",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.0.2"
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.4.19",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.19.tgz",
-      "integrity": "sha512-vm6+cogWrshjqEHTzIDCp72DKtea8Ry/QVpQRYoyTIg9k7QZDX6D8+HGURjtmatfgM8xgCFtJJaOlCaRYRK3QA==",
+      "version": "3.4.20",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.20.tgz",
+      "integrity": "sha512-/cSBGL79HFBYgDnqCNKErOav3bPde3n0sJwJM2Z09rXlkiowV/2SG1tgDAiWS1CatS4Cvo0o74e1vNeCK1R3RA==",
       "dev": true,
       "dependencies": {
-        "@vue/compiler-core": "3.4.19",
-        "@vue/shared": "3.4.19"
+        "@vue/compiler-core": "3.4.20",
+        "@vue/shared": "3.4.20"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.4.19",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.19.tgz",
-      "integrity": "sha512-LQ3U4SN0DlvV0xhr1lUsgLCYlwQfUfetyPxkKYu7dkfvx7g3ojrGAkw0AERLOKYXuAGnqFsEuytkdcComei3Yg==",
+      "version": "3.4.20",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.20.tgz",
+      "integrity": "sha512-nPuTZz0yxTPzjyYe+9nQQsFYImcz/57UX8N3jyhl5oIUUs2jqqAMaULsAlJwve3qNYfjQzq0bwy3pqJrN9ecZw==",
       "dev": true,
       "dependencies": {
         "@babel/parser": "^7.23.9",
-        "@vue/compiler-core": "3.4.19",
-        "@vue/compiler-dom": "3.4.19",
-        "@vue/compiler-ssr": "3.4.19",
-        "@vue/shared": "3.4.19",
+        "@vue/compiler-core": "3.4.20",
+        "@vue/compiler-dom": "3.4.20",
+        "@vue/compiler-ssr": "3.4.20",
+        "@vue/shared": "3.4.20",
         "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.6",
-        "postcss": "^8.4.33",
+        "magic-string": "^0.30.7",
+        "postcss": "^8.4.35",
         "source-map-js": "^1.0.2"
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.4.19",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.19.tgz",
-      "integrity": "sha512-P0PLKC4+u4OMJ8sinba/5Z/iDT84uMRRlrWzadgLA69opCpI1gG4N55qDSC+dedwq2fJtzmGald05LWR5TFfLw==",
+      "version": "3.4.20",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.20.tgz",
+      "integrity": "sha512-b3gFQPiHLvI12C56otzBPpQhZ5kgkJ5RMv/zpLjLC2BIFwX5GktDqYQ7xg0Q2grP6uFI8al3beVKvAVxFtXmIg==",
       "dev": true,
       "dependencies": {
-        "@vue/compiler-dom": "3.4.19",
-        "@vue/shared": "3.4.19"
+        "@vue/compiler-dom": "3.4.20",
+        "@vue/shared": "3.4.20"
       }
     },
     "node_modules/@vue/devtools-api": {
@@ -1085,52 +1085,52 @@
       }
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.4.19",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.19.tgz",
-      "integrity": "sha512-+VcwrQvLZgEclGZRHx4O2XhyEEcKaBi50WbxdVItEezUf4fqRh838Ix6amWTdX0CNb/b6t3Gkz3eOebfcSt+UA==",
+      "version": "3.4.20",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.20.tgz",
+      "integrity": "sha512-P5LJcxUkG6inlHr6MHVA4AVFAmRYJQ7ONGWJILNjMjoYuEXFhYviSCb9BEMyszSG/1kWCZbtWQlKSLasFRpThw==",
       "dev": true,
       "dependencies": {
-        "@vue/shared": "3.4.19"
+        "@vue/shared": "3.4.20"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.4.19",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.19.tgz",
-      "integrity": "sha512-/Z3tFwOrerJB/oyutmJGoYbuoadphDcJAd5jOuJE86THNZji9pYjZroQ2NFsZkTxOq0GJbb+s2kxTYToDiyZzw==",
+      "version": "3.4.20",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.20.tgz",
+      "integrity": "sha512-MPvsQpGAxoBqLHjqopt4YPtUYBpq0K6oAWDTwIR1CTNZ3y9O/J2ZVh+i2JpxKNYwANJBiZ20O99NE20uisB7xw==",
       "dev": true,
       "dependencies": {
-        "@vue/reactivity": "3.4.19",
-        "@vue/shared": "3.4.19"
+        "@vue/reactivity": "3.4.20",
+        "@vue/shared": "3.4.20"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.4.19",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.19.tgz",
-      "integrity": "sha512-IyZzIDqfNCF0OyZOauL+F4yzjMPN2rPd8nhqPP2N1lBn3kYqJpPHHru+83Rkvo2lHz5mW+rEeIMEF9qY3PB94g==",
+      "version": "3.4.20",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.20.tgz",
+      "integrity": "sha512-OkbPVP69H+8m74543zMAAx/LIkajxufYyow41gc0s5iF0uplT5uTQ4llDYu1GeJZEI8wjL5ueiPQruk4qwOMmA==",
       "dev": true,
       "dependencies": {
-        "@vue/runtime-core": "3.4.19",
-        "@vue/shared": "3.4.19",
+        "@vue/runtime-core": "3.4.20",
+        "@vue/shared": "3.4.20",
         "csstype": "^3.1.3"
       }
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.4.19",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.19.tgz",
-      "integrity": "sha512-eAj2p0c429RZyyhtMRnttjcSToch+kTWxFPHlzGMkR28ZbF1PDlTcmGmlDxccBuqNd9iOQ7xPRPAGgPVj+YpQw==",
+      "version": "3.4.20",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.20.tgz",
+      "integrity": "sha512-w3VH2GuwxQHA6pJo/HCV22OfVC8Mw4oeHQM+vKeqtRK0OPE1Wilnh+P/SDVGGxPjJsGmyfphi0dbw8UKZQJH9w==",
       "dev": true,
       "dependencies": {
-        "@vue/compiler-ssr": "3.4.19",
-        "@vue/shared": "3.4.19"
+        "@vue/compiler-ssr": "3.4.20",
+        "@vue/shared": "3.4.20"
       },
       "peerDependencies": {
-        "vue": "3.4.19"
+        "vue": "3.4.20"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.4.19",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.19.tgz",
-      "integrity": "sha512-/KliRRHMF6LoiThEy+4c1Z4KB/gbPrGjWwJR+crg2otgrf/egKzRaCPvJ51S5oetgsgXLfc4Rm5ZgrKHZrtMSw==",
+      "version": "3.4.20",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.20.tgz",
+      "integrity": "sha512-KTEngal0aiUvNJ6I1Chk5Ew5XqChsFsxP4GKAYXWb99zKJWjNU72p2FWEOmZWHxHcqtniOJsgnpd3zizdpfEag==",
       "dev": true
     },
     "node_modules/@vuepic/vue-datepicker": {
@@ -4033,16 +4033,16 @@
       }
     },
     "node_modules/vue": {
-      "version": "3.4.19",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.4.19.tgz",
-      "integrity": "sha512-W/7Fc9KUkajFU8dBeDluM4sRGc/aa4YJnOYck8dkjgZoXtVsn3OeTGni66FV1l3+nvPA7VBFYtPioaGKUmEADw==",
+      "version": "3.4.20",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.4.20.tgz",
+      "integrity": "sha512-xF4zDKXp67NjgORFX/HOuaiaKYjgxkaToK0KWglFQEYlCw9AqgBlj1yu5xa6YaRek47w2IGiuvpvrGg/XuQFCw==",
       "dev": true,
       "dependencies": {
-        "@vue/compiler-dom": "3.4.19",
-        "@vue/compiler-sfc": "3.4.19",
-        "@vue/runtime-dom": "3.4.19",
-        "@vue/server-renderer": "3.4.19",
-        "@vue/shared": "3.4.19"
+        "@vue/compiler-dom": "3.4.20",
+        "@vue/compiler-sfc": "3.4.20",
+        "@vue/runtime-dom": "3.4.20",
+        "@vue/server-renderer": "3.4.20",
+        "@vue/shared": "3.4.20"
       },
       "peerDependencies": {
         "typescript": "*"
@@ -4799,53 +4799,53 @@
       }
     },
     "@vue/compiler-core": {
-      "version": "3.4.19",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.19.tgz",
-      "integrity": "sha512-gj81785z0JNzRcU0Mq98E56e4ltO1yf8k5PQ+tV/7YHnbZkrM0fyFyuttnN8ngJZjbpofWE/m4qjKBiLl8Ju4w==",
+      "version": "3.4.20",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.20.tgz",
+      "integrity": "sha512-l7M+xUuL8hrGtRLkrf+62d9zucAdgqNBTbJ/NufCOIuJQhauhfyAKH9ra/qUctCXcULwmclGAVpvmxjbBO30qg==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.23.9",
-        "@vue/shared": "3.4.19",
+        "@vue/shared": "3.4.20",
         "entities": "^4.5.0",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.0.2"
       }
     },
     "@vue/compiler-dom": {
-      "version": "3.4.19",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.19.tgz",
-      "integrity": "sha512-vm6+cogWrshjqEHTzIDCp72DKtea8Ry/QVpQRYoyTIg9k7QZDX6D8+HGURjtmatfgM8xgCFtJJaOlCaRYRK3QA==",
+      "version": "3.4.20",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.20.tgz",
+      "integrity": "sha512-/cSBGL79HFBYgDnqCNKErOav3bPde3n0sJwJM2Z09rXlkiowV/2SG1tgDAiWS1CatS4Cvo0o74e1vNeCK1R3RA==",
       "dev": true,
       "requires": {
-        "@vue/compiler-core": "3.4.19",
-        "@vue/shared": "3.4.19"
+        "@vue/compiler-core": "3.4.20",
+        "@vue/shared": "3.4.20"
       }
     },
     "@vue/compiler-sfc": {
-      "version": "3.4.19",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.19.tgz",
-      "integrity": "sha512-LQ3U4SN0DlvV0xhr1lUsgLCYlwQfUfetyPxkKYu7dkfvx7g3ojrGAkw0AERLOKYXuAGnqFsEuytkdcComei3Yg==",
+      "version": "3.4.20",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.20.tgz",
+      "integrity": "sha512-nPuTZz0yxTPzjyYe+9nQQsFYImcz/57UX8N3jyhl5oIUUs2jqqAMaULsAlJwve3qNYfjQzq0bwy3pqJrN9ecZw==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.23.9",
-        "@vue/compiler-core": "3.4.19",
-        "@vue/compiler-dom": "3.4.19",
-        "@vue/compiler-ssr": "3.4.19",
-        "@vue/shared": "3.4.19",
+        "@vue/compiler-core": "3.4.20",
+        "@vue/compiler-dom": "3.4.20",
+        "@vue/compiler-ssr": "3.4.20",
+        "@vue/shared": "3.4.20",
         "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.6",
-        "postcss": "^8.4.33",
+        "magic-string": "^0.30.7",
+        "postcss": "^8.4.35",
         "source-map-js": "^1.0.2"
       }
     },
     "@vue/compiler-ssr": {
-      "version": "3.4.19",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.19.tgz",
-      "integrity": "sha512-P0PLKC4+u4OMJ8sinba/5Z/iDT84uMRRlrWzadgLA69opCpI1gG4N55qDSC+dedwq2fJtzmGald05LWR5TFfLw==",
+      "version": "3.4.20",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.20.tgz",
+      "integrity": "sha512-b3gFQPiHLvI12C56otzBPpQhZ5kgkJ5RMv/zpLjLC2BIFwX5GktDqYQ7xg0Q2grP6uFI8al3beVKvAVxFtXmIg==",
       "dev": true,
       "requires": {
-        "@vue/compiler-dom": "3.4.19",
-        "@vue/shared": "3.4.19"
+        "@vue/compiler-dom": "3.4.20",
+        "@vue/shared": "3.4.20"
       }
     },
     "@vue/devtools-api": {
@@ -4892,49 +4892,49 @@
       }
     },
     "@vue/reactivity": {
-      "version": "3.4.19",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.19.tgz",
-      "integrity": "sha512-+VcwrQvLZgEclGZRHx4O2XhyEEcKaBi50WbxdVItEezUf4fqRh838Ix6amWTdX0CNb/b6t3Gkz3eOebfcSt+UA==",
+      "version": "3.4.20",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.20.tgz",
+      "integrity": "sha512-P5LJcxUkG6inlHr6MHVA4AVFAmRYJQ7ONGWJILNjMjoYuEXFhYviSCb9BEMyszSG/1kWCZbtWQlKSLasFRpThw==",
       "dev": true,
       "requires": {
-        "@vue/shared": "3.4.19"
+        "@vue/shared": "3.4.20"
       }
     },
     "@vue/runtime-core": {
-      "version": "3.4.19",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.19.tgz",
-      "integrity": "sha512-/Z3tFwOrerJB/oyutmJGoYbuoadphDcJAd5jOuJE86THNZji9pYjZroQ2NFsZkTxOq0GJbb+s2kxTYToDiyZzw==",
+      "version": "3.4.20",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.20.tgz",
+      "integrity": "sha512-MPvsQpGAxoBqLHjqopt4YPtUYBpq0K6oAWDTwIR1CTNZ3y9O/J2ZVh+i2JpxKNYwANJBiZ20O99NE20uisB7xw==",
       "dev": true,
       "requires": {
-        "@vue/reactivity": "3.4.19",
-        "@vue/shared": "3.4.19"
+        "@vue/reactivity": "3.4.20",
+        "@vue/shared": "3.4.20"
       }
     },
     "@vue/runtime-dom": {
-      "version": "3.4.19",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.19.tgz",
-      "integrity": "sha512-IyZzIDqfNCF0OyZOauL+F4yzjMPN2rPd8nhqPP2N1lBn3kYqJpPHHru+83Rkvo2lHz5mW+rEeIMEF9qY3PB94g==",
+      "version": "3.4.20",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.20.tgz",
+      "integrity": "sha512-OkbPVP69H+8m74543zMAAx/LIkajxufYyow41gc0s5iF0uplT5uTQ4llDYu1GeJZEI8wjL5ueiPQruk4qwOMmA==",
       "dev": true,
       "requires": {
-        "@vue/runtime-core": "3.4.19",
-        "@vue/shared": "3.4.19",
+        "@vue/runtime-core": "3.4.20",
+        "@vue/shared": "3.4.20",
         "csstype": "^3.1.3"
       }
     },
     "@vue/server-renderer": {
-      "version": "3.4.19",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.19.tgz",
-      "integrity": "sha512-eAj2p0c429RZyyhtMRnttjcSToch+kTWxFPHlzGMkR28ZbF1PDlTcmGmlDxccBuqNd9iOQ7xPRPAGgPVj+YpQw==",
+      "version": "3.4.20",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.20.tgz",
+      "integrity": "sha512-w3VH2GuwxQHA6pJo/HCV22OfVC8Mw4oeHQM+vKeqtRK0OPE1Wilnh+P/SDVGGxPjJsGmyfphi0dbw8UKZQJH9w==",
       "dev": true,
       "requires": {
-        "@vue/compiler-ssr": "3.4.19",
-        "@vue/shared": "3.4.19"
+        "@vue/compiler-ssr": "3.4.20",
+        "@vue/shared": "3.4.20"
       }
     },
     "@vue/shared": {
-      "version": "3.4.19",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.19.tgz",
-      "integrity": "sha512-/KliRRHMF6LoiThEy+4c1Z4KB/gbPrGjWwJR+crg2otgrf/egKzRaCPvJ51S5oetgsgXLfc4Rm5ZgrKHZrtMSw==",
+      "version": "3.4.20",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.20.tgz",
+      "integrity": "sha512-KTEngal0aiUvNJ6I1Chk5Ew5XqChsFsxP4GKAYXWb99zKJWjNU72p2FWEOmZWHxHcqtniOJsgnpd3zizdpfEag==",
       "dev": true
     },
     "@vuepic/vue-datepicker": {
@@ -6796,16 +6796,16 @@
       }
     },
     "vue": {
-      "version": "3.4.19",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.4.19.tgz",
-      "integrity": "sha512-W/7Fc9KUkajFU8dBeDluM4sRGc/aa4YJnOYck8dkjgZoXtVsn3OeTGni66FV1l3+nvPA7VBFYtPioaGKUmEADw==",
+      "version": "3.4.20",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.4.20.tgz",
+      "integrity": "sha512-xF4zDKXp67NjgORFX/HOuaiaKYjgxkaToK0KWglFQEYlCw9AqgBlj1yu5xa6YaRek47w2IGiuvpvrGg/XuQFCw==",
       "dev": true,
       "requires": {
-        "@vue/compiler-dom": "3.4.19",
-        "@vue/compiler-sfc": "3.4.19",
-        "@vue/runtime-dom": "3.4.19",
-        "@vue/server-renderer": "3.4.19",
-        "@vue/shared": "3.4.19"
+        "@vue/compiler-dom": "3.4.20",
+        "@vue/compiler-sfc": "3.4.20",
+        "@vue/runtime-dom": "3.4.20",
+        "@vue/server-renderer": "3.4.20",
+        "@vue/shared": "3.4.20"
       }
     },
     "vue-router": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "files": [
     "dist"
   ],
-  "version": "1.8.10",
+  "version": "1.8.11",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "uplot": "^1.6.30",
     "vite": "^5.1.4",
     "vite-plugin-purgecss": "^0.2.12",
-    "vue": "^3.4.19",
+    "vue": "^3.4.20",
     "vue-router": "^4.3.0",
     "vue-tsc": "^1.8.27"
   }

--- a/src/DataChart/Chart.vue
+++ b/src/DataChart/Chart.vue
@@ -87,7 +87,7 @@
 <template>
   <div class="data-chart">
     <h1 :class="{ 'show': props.chartDataLoading || noChartData }" class="data-chart-notice">
-      <span :class="{ 'spin': props.chartDataLoading }" class="material-symbols-outlined">
+      <span translate="no" :class="{ 'spin': props.chartDataLoading }" class="material-symbols-outlined">
         {{ messageSymbol }}
       </span>
       <br/>

--- a/src/DataChart/DataChart.vue
+++ b/src/DataChart/DataChart.vue
@@ -61,7 +61,7 @@
   <div class="backdrop is-flex is-flex-direction-column is-align-items-center is-justify-content-center" :class="{ 'visible': chartExpanded }">
     <div :class="{ 'expanded': chartExpanded }" class="data-control is-flex is-flex-direction-column is-align-items-center card pb-4 pt-2 mb-6">
       <span v-if="!chartExpanded" class="expand icon is-clickable fullscreen-svg" title="Expand Chart" @click="toggleChart"></span>
-      <span v-else class="expand icon is-clickable material-symbols-outlined" v-on:click="toggleChart">close</span>
+      <span v-else translate="no" class="expand icon is-clickable material-symbols-outlined" v-on:click="toggleChart">close</span>
 
       <div class="date-control mt-2 is-flex is-align-items-center is-justify-content-space-evenly">
         <div class="control">
@@ -73,7 +73,7 @@
           <br/>
           <button class="button is-small is-info is-size-7 has-text-weight-semibold" v-on:click="async () => await loadChartData()">
             <span class="icon is-small">
-              <span :class="{ 'spin': chartDataLoading }" class="material-symbols-outlined">
+              <span translate="no" :class="{ 'spin': chartDataLoading }" class="material-symbols-outlined">
                 refresh
               </span>
             </span>
@@ -90,7 +90,7 @@
         <div class="download control is-align-self-flex-end">
           <button class="button is-small is-success is-size-7 has-text-weight-semibold" v-on:click="csvDownload">
             <span class="icon is-small">
-              <span class="material-symbols-outlined">file_download</span>
+              <span translate="no" class="material-symbols-outlined">file_download</span>
             </span>
             <span>Download</span>
           </button>

--- a/src/DisplayOptions/DisplayOption.vue
+++ b/src/DisplayOptions/DisplayOption.vue
@@ -13,7 +13,7 @@
         <input v-if="option instanceof Checkbox" type="checkbox" v-model="option.model.value" />
         <input v-else-if="option instanceof RadioOption" type="radio" :value="option.value" v-model="option.model.value" />
         <span v-if="option.icon" class="icon" :class="option.icon.class">
-          <span class="material-symbols-outlined">
+          <span translate="no" class="material-symbols-outlined">
             {{ option.icon.id }}
           </span>
         </span>

--- a/src/DisplayOptions/DisplayOptions.vue
+++ b/src/DisplayOptions/DisplayOptions.vue
@@ -22,7 +22,7 @@
     <div class="dropdown-trigger">
       <button class="button" aria-haspopup="true" aria-controls="dropdown-display" v-on:click="toggleDisplayOptions">
         <span class="icon">
-          <span class="material-symbols-outlined">
+          <span translate="no" class="material-symbols-outlined">
             settings
           </span>
         </span>

--- a/src/DisplayOptions/MonitorMarkers.ts
+++ b/src/DisplayOptions/MonitorMarkers.ts
@@ -285,7 +285,7 @@ function genMonitorMapMarker(monitor: Monitor): L.ShapeMarker {
     <div class="is-flex is-flex-direction-row is-flex-wrap-nowrap">
       <div class="mr-2 px-1"
         style="background-color: ${ monitor.markerParams.value_color }; color: ${ readableColor(monitor.markerParams.value_color) }; border: solid ${ toHex(darken(monitor.markerParams.value_color, .1)) }; border-radius: 5px">
-        <p class="is-size-6 has-text-centered">PM 2.5</p>
+        <p translate="no" class="is-size-6 has-text-centered">PM 2.5</p>
         <p class="is-size-2 has-text-centered has-text-weight-semibold is-flex-grow-1">
           ${ Math.round(+monitor.data.latest[MonitorDisplayField]) }
         </p>

--- a/src/DisplayOptions/MonitorMarkers.ts
+++ b/src/DisplayOptions/MonitorMarkers.ts
@@ -286,7 +286,7 @@ function genMonitorMapMarker(monitor: Monitor): L.ShapeMarker {
       <div class="mr-2 px-1"
         style="background-color: ${ monitor.markerParams.value_color }; color: ${ readableColor(monitor.markerParams.value_color) }; border: solid ${ toHex(darken(monitor.markerParams.value_color, .1)) }; border-radius: 5px">
         <p translate="no" class="is-size-6 has-text-centered">PM 2.5</p>
-        <p class="is-size-2 has-text-centered has-text-weight-semibold is-flex-grow-1">
+        <p translate="no" class="is-size-2 has-text-centered has-text-weight-semibold is-flex-grow-1">
           ${ Math.round(+monitor.data.latest[MonitorDisplayField]) }
         </p>
         <p>(${ parseInt(displayField.updateDuration, 10) } min avg)</p>

--- a/src/EVCharging/mod.ts
+++ b/src/EVCharging/mod.ts
@@ -12,7 +12,7 @@ export function genEvStationMapMarker(evStation: IEvStation, pane: string): Mark
   };
 
   const icon = L.divIcon({
-    html: '<span class="material-symbols-outlined">ev_station</span>',
+    html: '<span translate="no" class="material-symbols-outlined">ev_station</span>',
     className: "leaflet-ev-icon".concat(` ${ iconClass }`),
     iconSize: [30, 30]
   });
@@ -78,7 +78,7 @@ function evCardsAcceptedTemplate(evStation: IEvStation) {
     const cardTags = evStation.cards_accepted!.split(",")
       .map(part => `
         <span class="tag">
-          <span class="material-symbols-outlined is-size-5">
+          <span translate="no" class="material-symbols-outlined is-size-5">
             credit_card
           </span>
           ${ part.trim() }
@@ -93,7 +93,7 @@ function evConnectorTypesTemplate(evStation: IEvStation) {
   return createTemplate(evStation.ev_connector_types, () => {
     const plugTags = evStation.ev_connector_types.map(part => `
         <span class="tag is-success has-text-weight-semibold">
-          <span class="material-symbols-outlined is-size-5">
+          <span translate="no" class="material-symbols-outlined is-size-5">
             electrical_services
           </span>
           ${ part.trim() }

--- a/src/MonitorDataBox/MonitorDataBox.vue
+++ b/src/MonitorDataBox/MonitorDataBox.vue
@@ -16,7 +16,7 @@
 <template>
     <div v-if="value.length && props.styles" class="monitor-data-box monitor-data-temp" :style="styles">
       <p :translate="noTranslate ? 'no' : 'yes'" class="is-size-6 has-text-centered">{{ label }}</p>
-      <p class="is-size-2 has-text-centered is-flex-grow-1" v-html="value"></p>
+      <p translate="no" class="is-size-2 has-text-centered is-flex-grow-1" v-html="value"></p>
     </div>
 </template>
 

--- a/src/MonitorDataBox/MonitorDataBox.vue
+++ b/src/MonitorDataBox/MonitorDataBox.vue
@@ -3,18 +3,19 @@
   import type { StyleValue } from "vue";
 
   const props = defineProps<{
-    styles: StyleValue | undefined;
     label: string;
+    styles: StyleValue | undefined;
+    noTranslate?: boolean;
     value: string;
   }>();
 
-  const { styles, label, value } = toRefs(props);
+  const { label, styles, noTranslate, value } = toRefs(props);
 
 </script>
 
 <template>
     <div v-if="value.length && props.styles" class="monitor-data-box monitor-data-temp" :style="styles">
-      <p class="is-size-6 has-text-centered">{{ label }}</p>
+      <p :translate="noTranslate ? 'no' : 'yes'" class="is-size-6 has-text-centered">{{ label }}</p>
       <p class="is-size-2 has-text-centered is-flex-grow-1" v-html="value"></p>
     </div>
 </template>

--- a/src/MonitorDataBox/PM2DataBox.vue
+++ b/src/MonitorDataBox/PM2DataBox.vue
@@ -20,7 +20,7 @@
 </script>
 
 <template>
-  <MonitorDataBoxVue v-if="show" label="PM 2.5" :styles="styles" :value="value"></MonitorDataBoxVue>
+  <MonitorDataBoxVue v-if="show" :no-translate="true" label="PM 2.5" :styles="styles" :value="value"></MonitorDataBoxVue>
 </template>
 
 <style scoped>

--- a/src/MonitorDetails/MonitorDetails.vue
+++ b/src/MonitorDetails/MonitorDetails.vue
@@ -33,7 +33,7 @@
 
 <template>
   <div class="monitor-details is-flex is-align-items-center is-flex-direction-column">
-    <span class="close-btn material-symbols-outlined" v-on:click="close">close</span>
+    <span translate="no" class="close-btn material-symbols-outlined" v-on:click="close">close</span>
 
     <MonitorInfoVue class="mb-4" :monitor="activeMonitor"></MonitorInfoVue>
 

--- a/src/MonitorDetails/MonitorInfo.vue
+++ b/src/MonitorDetails/MonitorInfo.vue
@@ -26,7 +26,7 @@
       <li>
         <span class="tag is-light">
           <span class="icon">
-            <span class="material-symbols-outlined has-text-grey">router</span>
+            <span translate="no" class="material-symbols-outlined has-text-grey">router</span>
           </span>
           <span>{{ monitor.data.device }}</span>
         </span>
@@ -34,7 +34,7 @@
       <li v-if="monitor.data.county">
         <span class="tag is-light">
           <span class="icon">
-            <span class="material-symbols-outlined has-text-grey">location_on</span>
+            <span translate="no" class="material-symbols-outlined has-text-grey">location_on</span>
           </span>
           <span>{{ monitor.data.county }}</span>
         </span>
@@ -42,7 +42,7 @@
       <li>
         <span class="tag is-light">
           <span class="icon">
-            <span class="material-symbols-outlined has-text-grey is-slze-7">location_searching</span>
+            <span translate="no" class="material-symbols-outlined has-text-grey is-slze-7">location_searching</span>
           </span>
           <span>{{ location }}</span>
         </span>

--- a/src/MonitorSubscription/MonitorSubscription.vue
+++ b/src/MonitorSubscription/MonitorSubscription.vue
@@ -136,7 +136,7 @@ onMounted(async () => {
   <div v-if="validUser" class="monitor-subscription-wrapper">
     <div class="monitor-subscription-container">
 
-      <button @click="toggleDropdown" :class="[{ 'is-success': subscribed }, 'is-info']"
+      <button translate="no" @click="toggleDropdown" :class="[{ 'is-success': subscribed }, 'is-info']"
         class="button is-small monitor-subscription-button is-size-7 has-text-weight-semibold">
         {{ buttonText }} <span :class="{ 'rotate': active }" class="material-symbols-outlined">expand_more</span>
       </button>

--- a/src/WidgetModal/WidgetModal.vue
+++ b/src/WidgetModal/WidgetModal.vue
@@ -52,7 +52,7 @@
         <!--
         <iframe :src="iframeSrc" frameborder="0" allowtransparency="true" :style="widgetStyles"></iframe>
         -->
-        <div class="iframe" v-html="iframeCode"></div>
+        <div translate="no" class="iframe" v-html="iframeCode"></div>
         <p class="has-text-centered">Copy the following code and paste it in your website</p>
         <div class="code">
           <code>

--- a/src/WidgetModal/WidgetModal.vue
+++ b/src/WidgetModal/WidgetModal.vue
@@ -48,7 +48,7 @@
 
     <div class="modal-background" :class="{ visible: modalOpen}" @click.self="closeModal">
       <div class="my-modal">
-        <span class="close-btn material-symbols-outlined" @click.self="closeModal">close</span>
+        <span translate="no" class="close-btn material-symbols-outlined" @click.self="closeModal">close</span>
         <!--
         <iframe :src="iframeSrc" frameborder="0" allowtransparency="true" :style="widgetStyles"></iframe>
         -->
@@ -58,7 +58,7 @@
           <code>
             {{ iframeCode }}
           </code>
-          <span class="material-symbols-outlined" @click.self="copyToClipboard()">
+          <span translate="no" class="material-symbols-outlined" @click.self="copyToClipboard()">
             content_copy
           </span>
           <div class="copied-notice" :class="{ visible: copied }">


### PR DESCRIPTION
The Google Translate toolbar does not mesh well with Google Material Symbols. The `translate` attribute has been set to `no` on all material symbol elements to prevent the icon text from being replaced with a translation.